### PR TITLE
Adjust required Autoconf version.

### DIFF
--- a/README
+++ b/README
@@ -133,6 +133,20 @@ mod_auth_cas.
 
 Compatibility with other versions will depend on those other libraries.
 
+To develop/test mod_auth_cas, the following Debian packages are necessary:
+apache2-threaded-dev
+autoconf
+automake
+check
+libapr1-dev
+libaprutil1-dev
+libcurl4-openssl-dev
+make
+pkg-config
+
+(this list should not be considered exhaustive)
+
+
 INSTALLATION INSTRUCTIONS
 --------------------------------------------------------------------
 Ensure that the follow files are in the working directory:
@@ -386,29 +400,12 @@ Description:	mod_auth_cas will strip request inbound request headers that may ha
 		CASAuthNHeader value. 
 
 ====================================================================
-CONTRIBUTORS 
-====================================================================  
-Author:
-Phil Ames 	<modauthcas [at] gmail [dot] com>
-
-Designers:
-Phil Ames 	<modauthcas [at] gmail [dot] com>
-Matt Smith 	<matt [dot] smith [at] uconn [dot] edu>
-
-Frequent Community Contributors:
-Ben Noordhuis
-Chris Adams
-David Hawes
-David Ohsie
-
-Portions of this module are based on code from a CAS module by Yale.
-See comments in mod_auth_cas.c
-
-====================================================================
 CONTACT INFORMATION AND WEBSITE
 ====================================================================
 We welcome your feedback, suggestions and contributions. Contact us
 via email if you have questions, feedback, code submissions, 
-and bug reports.
+and bug reports.  To reach the development team, send an e-mail to:
+
+mod-auth-cas-dev [at] lists [dot] jasig [dot] org
 
 ====================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([mod_auth_cas], [1.0.10], [modauthcas@gmail.com])
+AC_INIT([mod_auth_cas], [1.0.10], [mod-auth-cas-dev@lists.jasig.org])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])
 AM_CONFIG_HEADER([config.h])

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2010 Phillip Ames / Matt Smith
+ * Copyright 2011 the mod_auth_cas team. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,8 @@
  * Apache CAS Authentication Module
  * Version 1.0.9.1
  *
- * Author:
- * Phil Ames       <modauthcas [at] gmail [dot] com>
- * Designers:
- * Phil Ames       <modauthcas [at] gmail [dot] com>
- * Matt Smith      <matt [dot] smith [at] uconn [dot] edu>
+ * Contact: mod-auth-cas-dev@lists.jasig.org
+ *
  */
 
 #include <sys/types.h>

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2010 Phillip Ames / Matt Smith
+ * Copyright 2011 the mod_auth_cas team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,8 @@
  * Apache CAS Authentication Module
  * Version 1.0.9.1
  *
- * Author:
- * Phil Ames       <modauthcas [at] gmail [dot] com>
- * Designers:
- * Phil Ames       <modauthcas [at] gmail [dot] com>
- * Matt Smith      <matt [dot] smith [at] uconn [dot] edu>
+ * Contact: mod-auth-cas-dev@lists.jasig.org
+ *
  */
 
 #ifndef MOD_AUTH_CAS_H


### PR DESCRIPTION
@smaresca or @forsetti do you know any reason why the previous minimum version was 2.65 ?  I'd like to get this building on my OS X machine in addition to my Debian box, and this doesn't seem to have any ill effects from an autoconf perspective.
