### PR TITLE
libcurl version is currently not detected properly, and REDIR_PROTOCOLS is not properly ignored in libcurl version too old

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1589,7 +1589,6 @@ char *getResponseFromServer (request_rec *r, cas_cfg *c, char *ticket)
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curlError);
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
-	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 
 	curlBuffer.written = 0;
 	memset(curlBuffer.buf, '\0', sizeof(curlBuffer.buf));
@@ -1599,6 +1598,7 @@ char *getResponseFromServer (request_rec *r, cas_cfg *c, char *ticket)
 	curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, c);
 
 #ifndef LIBCURL_NO_CURLPROTO
+	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 	curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 #endif
 

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -37,7 +37,7 @@
 #endif
 
 #include "curl/curlver.h"
-#if (LIBCURL_VERSION_NUM < 0x00071904)
+#if (LIBCURL_VERSION_NUM < 0x071304)
 #define LIBCURL_NO_CURLPROTO
 #endif
 


### PR DESCRIPTION
Fix LIBCURL_NO_CURLPROTO usage with CURLOPT_REDIR_PROTOCOLS, and LIBCURL_NO_CURLPROTO determination by correcting use of LIBCURL_VERSION_NUM
