### PR TITLE
Format check on service ticket

### DIFF
--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -43,6 +43,10 @@
 #define LIBCURL_NO_CURLPROTO
 #endif
 
+#include "pcre.h"
+#define OVECCOUNT 3    /* should be a multiple of 3 */
+#define TICKETPATTERN "^ticket=[SP]T-[a-zA-Z0-9-]+$"
+
 #include "cas_saml_attr.h"
 
 #ifndef AP_SERVER_MAJORVERSION_NUMBER


### PR DESCRIPTION
- new include: pcre
- regex pattern: "^ticket=[SP]T-[a-zA-Z0-9-]+$"
- function getCASTicket: regex match on service tickets starting with "ST-" or "PT-"
- tickets failing check are noted in error log and then ignored

This change prevents XML injection via the service parameter. The pattern is based on http://www.jasig.org/cas/protocol section 3.7 (thanks to Phil for the hint).

CAUTION: I am not a developer. So please the code carefully. It is based on pcredemo.c from pcre.
