### PR TITLE
Minor fixes

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2067,17 +2067,22 @@ int cas_authenticate(request_rec *r)
 					char *csvs = NULL;
 					while(av != NULL) {
 						if(csvs != NULL) {
-							csvs = apr_psprintf(r->pool, "%s%s%s", csvs, c->CASAttributeDelimiter, av->value);
+							csvs = apr_psprintf(r->pool, "%s%s%s", csvs,
+								c->CASAttributeDelimiter, av->value);
 						} else {
 							csvs = apr_psprintf(r->pool, "%s", av->value);
 						}
 						av = av->next;
 					}
 					//Set attributes in headers
-					apr_table_set(r->headers_in, apr_psprintf(r->pool, "%s%s", c->CASAttributePrefix, normalizeHeaderName(r, a->attr)), csvs);
+					apr_table_set(r->headers_in, apr_psprintf(r->pool, "%s%s",
+						c->CASAttributePrefix, normalizeHeaderName(r, a->attr)),
+						csvs);
 					
 					//Export attributes to environment
-					apr_env_set(apr_psprintf(r->pool, "%s%s", c->CASAttributePrefix, normalizeHeaderName(r, a->attr)),csvs,r->pool);
+					apr_env_set(apr_psprintf(r->pool, "%s%s",
+						c->CASAttributePrefix, normalizeHeaderName(r, a->attr)),
+						csvs, r->pool);
 					a = a->next;
 				}
 			}


### PR DESCRIPTION
As described in email to @pames:
"""
- SAML attributes are not exported to the environment, so they are unavailble for CGI.  They are available for authorization (require cas-attribute) and to other Apache mods (mod_php, etc).  A simple "apr_env_set(a->attr,csvs,r->pool);" will fix that.
- SAML attributes are only stuffed into the headers if CASAuthNHeader is set (mod_auth_cas.c:2061).  CASAuthNHeader is meant to create a header with the contents of REMOTE_USER for applications with specific header requirements, but currently it also is used to signal that attributes should be added to the headers. I believe the correct approach is simply to move the attr handling outside of the if(d->CASAuthNHeader != NULL) block, unless someone can explain the rationale for the current code.
  """
