### PR TITLE
Fix ac header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.61])
 AC_INIT([mod_auth_cas], [1.0.10], [mod-auth-cas-dev@lists.jasig.org])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AC_LIBTOOL_DLOPEN
 AC_CANONICAL_BUILD


### PR DESCRIPTION
In order to build on OS X, I had to change the AC header as this patch does. I'm not sure if this is correct on other platforms :-/
