### PR TITLE
Use the hostname from the request instead of the VirtualHost when redirecting

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -590,7 +590,7 @@ char *getCASService(const request_rec *r, const cas_cfg *c)
 			port_str = apr_psprintf(r->pool, "%%3a%u", port);
 
 		service = apr_pstrcat(r->pool, scheme, "%3a%2f%2f",
-			r->server->server_hostname,
+			r->hostname,
 			port_str, escapeString(r, r->uri),
 			(r->args != NULL && *r->args != '\0' ? "%3f" : ""),
 			escapeString(r, r->args), NULL);
@@ -2081,14 +2081,14 @@ int cas_authenticate(request_rec *r)
 				} else {
 #ifdef APACHE2_0
 					if(printPort == TRUE)
-						newLocation = apr_psprintf(r->pool, "%s://%s:%u%s%s%s", ap_http_method(r), r->server->server_hostname, r->connection->local_addr->port, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
+						newLocation = apr_psprintf(r->pool, "%s://%s:%u%s%s%s", ap_http_method(r), r->hostname, r->connection->local_addr->port, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
 					else
-						newLocation = apr_psprintf(r->pool, "%s://%s%s%s%s", ap_http_method(r), r->server->server_hostname, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
+						newLocation = apr_psprintf(r->pool, "%s://%s%s%s%s", ap_http_method(r), r->hostname, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
 #else
 					if(printPort == TRUE)
-						newLocation = apr_psprintf(r->pool, "%s://%s:%u%s%s%s", ap_http_scheme(r), r->server->server_hostname, r->connection->local_addr->port, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
+						newLocation = apr_psprintf(r->pool, "%s://%s:%u%s%s%s", ap_http_scheme(r), r->hostname, r->connection->local_addr->port, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
 					else
-						newLocation = apr_psprintf(r->pool, "%s://%s%s%s%s", ap_http_scheme(r), r->server->server_hostname, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
+						newLocation = apr_psprintf(r->pool, "%s://%s%s%s%s", ap_http_scheme(r), r->hostname, r->uri, ((r->args != NULL) ? "?" : ""), ((r->args != NULL) ? r->args : ""));
 #endif
 				}
 				apr_table_add(r->headers_out, "Location", newLocation);


### PR DESCRIPTION
When configuring mod_auth_cas on a VirtualHost with several aliased domains,
mod_auth_cas would always generate redirections or service URIs pointing at
the VirtualHost ServerName, instead of the incoming request Hostname.

This breaks mod_auth_cas in a subtle way when using it in the context of a
VirtualHost setup such as the one described in
http://httpd.apache.org/docs/2.2/vhosts/mass.html#xtra-conf
