### PR TITLE
Update SSL directives

### DIFF
--- a/README
+++ b/README
@@ -91,6 +91,9 @@ NEW FEATURES AND FUNCTIONS IN THIS RELEASE
   CASCertificatePath directive, or switch to communicating with
   the CAS server over standard HTTP.
 
+* CASAllowWildcardCert has been removed, as this has been a no-op for
+  some time (libcurl handles all validation).
+
 ====================================================================
 BUG FIXES
 ====================================================================
@@ -227,14 +230,6 @@ Directive:	CASValidateDepth
 Default:	9
 Description:	This directive will set the maximum depth for chained certificate
 		validation.  The default (according to OpenSSL documentation) is 9.
-
-Directive:	CASAllowWildcardCert
-Default:	Off
-Description:	This directive determines whether a wildcard certificate can be trusted
-		to verify the CAS server.  For instance, if the CAS server presents a
-		certificate for *.example.com and the hostname portion of the CASValidateURL
-		is 'cas.login.example.com', this directive (if enabled) will accept that
-		certificate.
 
 Directive: 	CASCertificatePath
 Default:	/etc/ssl/certs/

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -103,7 +103,6 @@ void *cas_create_server_config(apr_pool_t *pool, server_rec *svr)
 	c->CASVersion = CAS_DEFAULT_VERSION;
 	c->CASDebug = CAS_DEFAULT_DEBUG;
 	c->CASValidateDepth = CAS_DEFAULT_VALIDATE_DEPTH;
-	c->CASAllowWildcardCert = CAS_DEFAULT_ALLOW_WILDCARD_CERT;
 	c->CASCertificatePath = CAS_DEFAULT_CA_PATH;
 	c->CASCookiePath = CAS_DEFAULT_COOKIE_PATH;
 	c->CASCookieEntropy = CAS_DEFAULT_COOKIE_ENTROPY;
@@ -138,7 +137,6 @@ void *cas_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD)
 	c->CASVersion = (add->CASVersion != CAS_DEFAULT_VERSION ? add->CASVersion : base->CASVersion);
 	c->CASDebug = (add->CASDebug != CAS_DEFAULT_DEBUG ? add->CASDebug : base->CASDebug);
 	c->CASValidateDepth = (add->CASValidateDepth != CAS_DEFAULT_VALIDATE_DEPTH ? add->CASValidateDepth : base->CASValidateDepth);
-	c->CASAllowWildcardCert = (add->CASAllowWildcardCert != CAS_DEFAULT_ALLOW_WILDCARD_CERT ? add->CASAllowWildcardCert : base->CASAllowWildcardCert);
 	c->CASCertificatePath = (apr_strnatcasecmp(add->CASCertificatePath,CAS_DEFAULT_CA_PATH) != 0 ? add->CASCertificatePath : base->CASCertificatePath);
 	c->CASCookiePath = (apr_strnatcasecmp(add->CASCookiePath, CAS_DEFAULT_COOKIE_PATH) != 0 ? add->CASCookiePath : base->CASCookiePath);
 	c->CASCookieEntropy = (add->CASCookieEntropy != CAS_DEFAULT_COOKIE_ENTROPY ? add->CASCookieEntropy : base->CASCookieEntropy);
@@ -275,17 +273,6 @@ const char *cfg_readCASParameter(cmd_parms *cmd, void *cfg, const char *value)
 		case cmd_attribute_prefix:
 			c->CASAttributePrefix = apr_pstrdup(cmd->pool, value);
 		break;
-		case cmd_wildcard_cert:
-			// XXX this feature is broken now
-			/* if atoi() is used on value here with AP_INIT_FLAG, it works but results in a compile warning, so we use TAKE1 to avoid it */
-			if(apr_strnatcasecmp(value, "On") == 0)
-				c->CASAllowWildcardCert = TRUE;
-			else if(apr_strnatcasecmp(value, "Off") == 0)
-				c->CASAllowWildcardCert = FALSE;
-			else
-				return(apr_psprintf(cmd->pool, "MOD_AUTH_CAS: Invalid argument to CASAllowWildcardCert - must be 'On' or 'Off'"));
-		break;
-
 		case cmd_ca_path:
 			if(apr_stat(&f, value, APR_FINFO_TYPE, cmd->temp_pool) == APR_INCOMPLETE)
 				return(apr_psprintf(cmd->pool, "MOD_AUTH_CAS: Could not find Certificate Authority file '%s'", value));
@@ -2682,7 +2669,6 @@ const command_rec cas_cmds [] = {
 
 	/* ssl related options */
 	AP_INIT_TAKE1("CASValidateDepth", cfg_readCASParameter, (void *) cmd_validate_depth, RSRC_CONF, "Define the number of chained certificates required for a successful validation"),
-	AP_INIT_TAKE1("CASAllowWildcardCert", cfg_readCASParameter, (void *) cmd_wildcard_cert, RSRC_CONF, "Allow wildcards in certificates when performing validation (e.g. *.example.com) (On or Off)"),
 	AP_INIT_TAKE1("CASCertificatePath", cfg_readCASParameter, (void *) cmd_ca_path, RSRC_CONF, "Path to the X509 certificate for the CASServer Certificate Authority"),
 
 	/* pertinent CAS urls */

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -72,7 +72,6 @@
 #define CAS_DEFAULT_ATTRIBUTE_DELIMITER ","
 #define CAS_DEFAULT_ATTRIBUTE_PREFIX "CAS_"
 #define CAS_DEFAULT_VALIDATE_DEPTH 9
-#define CAS_DEFAULT_ALLOW_WILDCARD_CERT 0
 #define CAS_DEFAULT_CA_PATH "/etc/ssl/certs/"
 #define CAS_DEFAULT_COOKIE_PATH "/dev/null"
 #define CAS_DEFAULT_LOGIN_URL NULL
@@ -113,7 +112,6 @@ typedef struct cas_cfg {
 	unsigned int CASVersion;
 	unsigned int CASDebug;
 	unsigned int CASValidateDepth;
-	unsigned int CASAllowWildcardCert;
 	unsigned int CASCacheCleanInterval;
 	unsigned int CASCookieEntropy;
 	unsigned int CASTimeout;
@@ -161,11 +159,11 @@ typedef struct cas_curl_buffer {
 } cas_curl_buffer;
 
 typedef enum {
-	cmd_version, cmd_debug, cmd_validate_depth, cmd_wildcard_cert,
-	cmd_ca_path, cmd_cookie_path, cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy,
-	cmd_session_timeout, cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_httponly,
-	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix, cmd_root_proxied_as,
-	cmd_authoritative
+	cmd_version, cmd_debug, cmd_validate_depth, cmd_ca_path, cmd_cookie_path,
+	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
+	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_httponly,
+	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix,
+	cmd_root_proxied_as, cmd_authoritative
 } valid_cmds;
 
 module AP_MODULE_DECLARE_DATA auth_cas_module;


### PR DESCRIPTION
I noticed another post on the mailing list with CASValidateServer Off.  I'd like to make good on killing it, and clean up the other no-op directive.
