### PR TITLE
Fix configure.ac to build with OpenSSL 1.1.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,6 @@ AC_SUBST(TEST_COVERAGE_CFLAGS)
 AX_CHECK_OPENSSL
 
 AC_CHECK_LIB([crypto],[CRYPTO_new_ex_data], [], [AC_MSG_ERROR([OpenSSL libraries required])])
-AC_CHECK_LIB([ssl],[SSL_library_init], [], [AC_MSG_ERROR([OpenSSL libraries required])])
 
 AC_CHECK_HEADERS([openssl/crypto.h openssl/x509.h openssl/pem.h openssl/ssl.h openssl/err.h],[],[AC_MSG_ERROR([OpenSSL headers required])])
 


### PR DESCRIPTION
I have not run autoreconf, if you want this to be part of the PR let me know.