### PR TITLE
Use a dynamic buffer to store the CAS validation response.

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1747,7 +1747,8 @@ size_t cas_curl_write(const void *ptr, size_t size, size_t nmemb, void *stream)
 	char *oldBuf = curlBuffer->buf;
 	apr_pool_t *oldPool = curlBuffer->subpool;
 
-	if (curlBuffer->written + realsize >= CAS_MAX_RESPONSE_SIZE) {
+	if (curlBuffer->written + realsize + 1 <= curlBuffer->written ||
+		curlBuffer->written + realsize >= CAS_MAX_RESPONSE_SIZE) {
 		return 0;
 	}
 

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1742,15 +1742,22 @@ apr_byte_t isValidCASCookie(request_rec *r, cas_cfg *c, char *cookie, char **use
 
 size_t cas_curl_write(const void *ptr, size_t size, size_t nmemb, void *stream)
 {
+	size_t realsize = size * nmemb;
 	cas_curl_buffer *curlBuffer = (cas_curl_buffer *) stream;
+	char *oldBuf = curlBuffer->buf;
 
-	if((nmemb*size) + curlBuffer->written >= CAS_MAX_RESPONSE_SIZE)
+	curlBuffer->buf = apr_pcalloc(curlBuffer->pool, curlBuffer->written + realsize + 1);
+	if(curlBuffer->buf == NULL) {
 		return 0;
+	}
 
-	memcpy((curlBuffer->buf + curlBuffer->written), ptr, (nmemb*size));
-	curlBuffer->written += (nmemb*size);
+	memcpy(curlBuffer->buf, oldBuf, curlBuffer->written);
+	memcpy(&(curlBuffer->buf[curlBuffer->written]), ptr, realsize);
 
-	return (nmemb*size);
+	curlBuffer->written += realsize;
+	curlBuffer->buf[curlBuffer->written] = 0;
+
+	return realsize;
 }
 
 CURLcode cas_curl_ssl_ctx(CURL *curl, void *sslctx, void *parm)
@@ -1793,8 +1800,9 @@ char *getResponseFromServer (request_rec *r, cas_cfg *c, char *ticket)
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
 
+	curlBuffer.buf = NULL;
 	curlBuffer.written = 0;
-	memset(curlBuffer.buf, '\0', sizeof(curlBuffer.buf));
+	curlBuffer.pool = r->pool;
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &curlBuffer);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cas_curl_write);
 	curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, cas_curl_ssl_ctx);

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -102,6 +102,7 @@
 #define CAS_DEFAULT_SSO_ENABLED FALSE
 #define CAS_DEFAULT_AUTHORITATIVE FALSE
 
+#define CAS_MAX_RESPONSE_SIZE 2147483648
 #define CAS_MAX_ERROR_SIZE 1024
 #define CAS_MAX_XML_SIZE 1024
 
@@ -164,6 +165,7 @@ typedef struct cas_curl_buffer {
 	char *buf;
 	size_t written;
 	apr_pool_t *pool;
+	apr_pool_t *subpool;
 } cas_curl_buffer;
 
 typedef enum {

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -102,7 +102,6 @@
 #define CAS_DEFAULT_SSO_ENABLED FALSE
 #define CAS_DEFAULT_AUTHORITATIVE FALSE
 
-#define CAS_MAX_RESPONSE_SIZE 65536
 #define CAS_MAX_ERROR_SIZE 1024
 #define CAS_MAX_XML_SIZE 1024
 
@@ -162,8 +161,9 @@ typedef struct cas_cache_entry {
 } cas_cache_entry;
 
 typedef struct cas_curl_buffer {
-	char buf[CAS_MAX_RESPONSE_SIZE];
+	char *buf;
 	size_t written;
+	apr_pool_t *pool;
 } cas_curl_buffer;
 
 typedef enum {


### PR DESCRIPTION
Use a dynamic buffer to capture all of the response from the CAS
server.

This strategy is outlined in the example refereced here:

https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html

APR doesn't have a realloc(), so we call apr_pcalloc() on every call to
cas_curl_write(). This is wasteful. Should we create a separate memory
pool to handle this so we can free memory that is no longer used?

The CAS_MAX_RESPONSE_SIZE has been a pain point for my institution in the past. The bump to 64k gave us a temporary reprieve, but as we release more and more attributes this has started to be an issue again. This patch would allow us to not have to worry about those limits any more.