### PR TITLE
fix warning for Apache >= 2.4.30

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2845,4 +2845,7 @@ module AP_MODULE_DECLARE_DATA auth_cas_module = {
 	cas_merge_server_config,                  /* merge  per-server config structures */
 	cas_cmds,                  /* table of config file commands       */
 	cas_register_hooks  /* register hooks                      */
+#ifdef AP_MODULE_FLAG_NONE
+	, AP_MODULE_FLAG_NONE
+#endif
 };


### PR DESCRIPTION
```
mod_auth_cas.c: At top level:
mod_auth_cas.c:2848:1: warning: missing initializer for field ‘flags’ of
‘module {aka struct module_struct}’ [-Wmissing-field-initializers]
 };
 ^
In file included from mod_auth_cas.c:39:0:
/usr/include/apache2/http_config.h:420:9: note: ‘flags’ declared here
     int flags;
         ^~~~~
```
'int flags' was added to the end of the module_struct [in trunk September 2017](https://www.mail-archive.com/dev@httpd.apache.org/msg69500.html) and merged into the 2.4.x branch before 2.4.30.

Unfortunately they haven't updated their docs yet, but from what I can gather, the only flags currently defined are:
```
#define AP_MODULE_FLAG_NONE         (0)
#define AP_MODULE_FLAG_ALWAYS_MERGE (1 << 0)
```
**AP_MODULE_FLAG_NONE** (0) means no change, build as before (except `-Wmissing-field-initializers` will give you a warning if you don't include a flags member).

**AP_MODULE_FLAG_ALWAYS_MERGE** (1) apparently means to [always create a separate "merged" config for each vhost](https://www.mail-archive.com/dev@httpd.apache.org/msg70982.html), rather than copying the base config if there aren't any directives for the module in that vhost.  Apparently this was needed for making mod_ssl work with mod_md to automatically configure Let's Encrypt certs without any SSL config in the vhost, but any module which may have its config changed in post_config may need it.

I don't _think_ mod_auth_cas needs that, but you know better than me... my PR just explicitly sets FLAG_NONE (if defined) to silence the warning.