### PR TITLE
log attributes at debug; improve attribute documentation

### DIFF
--- a/README
+++ b/README
@@ -72,27 +72,32 @@ Set a few required parameters in your Apache configuration:
 	CASValidateURL https://login.example.org/cas/serviceValidate
 
 Protect a "Location" or "Directory" block in your Apache
-  configuration:
+configuration:
 
 	<Location /secured>
 		Authtype CAS
-		require valid-user
+		Require valid-user
 	</Location>
 
-If SAML-delivered attribute authorization is also desired, use the
-  samlValidate URL, enable SAML validation, and specify cas-attribute
-  in your require rule (please note: both attribute name and value are
-  case-sensitive):
+If attribute-based authorization is also desired, specify cas-attribute
+name:value in your Require rule (please note: both attribute name and value are
+case-sensitive):
 
-   	CASCookiePath /var/cache/apache2/mod_auth_cas/
+	CASCookiePath /var/cache/apache2/mod_auth_cas/
 	CASLoginURL https://login.example.org/cas/login
 	CASValidateURL https://login.example.org/cas/samlValidate
-    CASValidateSAML On
+	CASValidateSAML On
 
-    <Location /secured>
+	<Location /secured>
 		Authtype CAS
-        require cas-attribute edupersonaffiliation:staff
-     </Location>
+		Require cas-attribute edupersonaffiliation:staff
+	</Location>
+
+Both the CAS 2.0 and SAML 1.1 protocols support including additional attributes
+in the CAS validation response, which may also be added as HTTP headers (see
+CASAttributePrefix and CASAttributeDelimiter). This example uses the SAML
+protocol and requires that the 'edupersonaffiliation' attribute is set to
+'staff'.
 
 
 ========================================================================
@@ -175,8 +180,8 @@ Description:	The version of the CAS protocol to adhere to (1 or 2).
 Directive: 	CASDebug
 Default:	Off
 Description:	Enable or disable debugging mode for troubleshooting.  Please
-              note that LogLevel must be set to Debug for the VirtualHost in
-              order for these logs to be visible.
+		note that LogLevel must be set to Debug for the VirtualHost in
+		order for these logs to be visible.
 
 Directive:	CASValidateDepth
 Default:	9
@@ -287,7 +292,9 @@ Description:	This directive determines whether an optional authorization directi
 Directive:	CASValidateSAML
 Default:	Off
 Description:	If enabled, the response from the CAS Server will be parsed for SAML
-		attributes which will be associated with the user.
+		attributes which will be associated with the user.  Requires setting
+		CASValidateURL appropriately; typical URLs are of the form
+		https://login.example.org/cas/samlValidate.
 
 Valid Directory/.htaccess Directives
 ------------------------------------
@@ -339,8 +346,11 @@ Description:	The name of the cookie used to store whether or not the user has at
 
 Directive:	CASAuthNHeader
 Default:	None
-Description:	If enabled, this will store the user returned by CAS in an HTTP header
-		accessible to your web applications.
+Description:	If enabled, this will store the user returned by CAS in the specified
+		HTTP header accessible to your web applications, and any additional
+		attributes received in headers named according to CASAttributePrefix.
+		This is in addition to the REMOTE_USER environment variable, which is
+		always set to the CAS user.
 
 Directive:	CASSSOEnabled
 Default:	Off
@@ -350,9 +360,12 @@ Description:	If enabled, this activates support for Single Sign Out within the C
 
 Directive:	CASAttributePrefix
 Default:	CAS_
-Description:	mod_auth_cas will add a header named  <CASAttributePrefix><attr_name>
-		with the value of this header being the attribute values when SAML
-		validation is enabled.
+Description:	The prefix to use when adding CAS or SAML attributes to the HTTP headers,
+		which will be named <CASAttributePrefix><attr_name>.  CASAuthNHeader
+		must be set for this directive to be used.
+		NOTE: In Apache 2.4 and newer, headers containing "invalid" characters
+		(including underscores) are silently dropped, so you must set this to
+		a "valid" name containing only alphabetic characters and hyphens.
 
 Directive:	CASAttributeDelimiter
 Default:	,
@@ -368,7 +381,7 @@ Description:	mod_auth_cas will strip request inbound request headers that may ha
 
 Directive:	Require cas-attribute <attribute>:<value>
 Default:	NULL
-Description:	Use this directive to authorize based on SAML cas attributes
+Description:	Use this directive to authorize based on CAS or SAML attributes
 		returned via the session validation call. Multiple directives
 		are OR-ed. If directive is present with no attributes defined,
 		the request is declined. If value has spaces, wrap the pair in quotes.
@@ -376,7 +389,7 @@ Description:	Use this directive to authorize based on SAML cas attributes
 
 Directive:	Require cas-attribute <attribute>~<value>
 Default:	NULL
-Description:	Use this form of the directive to authorize based on SAML cas
+Description:	Use this form of the directive to authorize based on CAS or SAML
 		attributes returned via the session validation call. Multiple
 		directives are OR-ed. If directive is present with no attributes
 		defined, the request is declined. The value is interpreted as a

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1571,6 +1571,7 @@ apr_byte_t isValidCASTicket(request_rec *r, cas_cfg *c, char *ticket, char **use
 															const char *attr_value = NULL;
 															apr_xml_to_text(r->pool, attr_node, APR_XML_X2T_INNER, NULL, NULL, &attr_value, NULL);
 															cas_attr_builder_add(builder, attr_name, attr_value);
+															ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "MOD_AUTH_CAS: attribute %s=%s", attr_name, attr_value);
 														}
 														attr_node = attr_node->next;
 													}
@@ -1637,7 +1638,7 @@ apr_byte_t isValidCASTicket(request_rec *r, cas_cfg *c, char *ticket, char **use
 									const char *attr_value = NULL;
 									apr_xml_to_text(r->pool, node_attr, APR_XML_X2T_INNER, NULL, NULL, &attr_value, NULL);
 									cas_attr_builder_add(builder, node_attr->name, attr_value);
-									ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "MOD_AUTH_CAS: attribute %s %s", node_attr->name, attr_value);
+									ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "MOD_AUTH_CAS: attribute %s=%s", node_attr->name, attr_value);
 									node_attr = node_attr->next;
 								}
 							}


### PR DESCRIPTION
#110 added support for CAS 2.0/3.0 attributes, which is great, except that they were being logged as errors, which made me think this was a problem:
```
> [Mon Aug 27 17:38:14.677710 2018] [auth_cas:error] [pid 6859:tid 140486845073152] [client 10.95.0.242:43458]
MOD_AUTH_CAS: attribute uid 0123456789abcdef0123456789abcdef, referer: https://cas-dev.example.com/cas/login?service=https%3a%2f%2fstage2.example.com%2f
```
(repeat for each attribute)

But this is in fact just debug logging, so I turned the log level down.  (I could maybe see using INFO, but certainly not ERR!)  I noticed a comment in that PR that "this log message would be useful around line 1569" but it doesn't appear to have been added, so I went ahead and added this logging to the SAML attribute section also.

---

I've updated the README for the attribute handling parts, since most of them implied attributes were only present when using SAML, which is no longer the case, and also documented some other things which had tripped me up, notably:
* With CASValidateSAML on, you need a different CASValidateURL (typically `/cas/samlValidate` vs. `/cas/serviceValidate`). I didn't think our CAS server supported SAML, but that was just a misconfiguration on my part, since I hadn't changed the CASValidateURL.
* HTTP request headers for attributes are only set if CASAuthNHeader is also set (#101).
* Apache 2.4 drops "invalid" headers (including those with underscores in the name), so you need to change CASAttributePrefix from its default `CAS_` (#102).

Those last two may change, but I'm documenting the present state.  I also cleaned up some tabs/spaces; there doesn't seem to be a consistent line length but I tried to at least match the surrounding context.