### PR TITLE
Prevent infinite redirect loops for subsequent CAS responses

### DIFF
--- a/README
+++ b/README
@@ -296,6 +296,13 @@ Description:	If enabled, the response from the CAS Server will be parsed for SAM
 		CASValidateURL appropriately; typical URLs are of the form
 		https://login.example.org/cas/samlValidate.
 
+Directive:	CASAllowSubAuth
+Default:	Off
+Description:	This directive determines whether subsequent CAS authentication
+		responses are allowed pass through, leaving the ticket parameter intact.
+		Helps prevent infinite redirect loops when CAS protection is being used
+		at multiple levels.
+
 Valid Directory/.htaccess Directives
 ------------------------------------
 Directive:	CASScope

--- a/README
+++ b/README
@@ -299,7 +299,7 @@ Description:	If enabled, the response from the CAS Server will be parsed for SAM
 Directive:	CASAllowSubAuth
 Default:	Off
 Description:	This directive determines whether subsequent CAS authentication
-		responses are allowed pass through, leaving the ticket parameter intact.
+		responses are allowed to pass through, leaving the ticket parameter intact.
 		Helps prevent infinite redirect loops when CAS protection is being used
 		at multiple levels.
 

--- a/README
+++ b/README
@@ -296,7 +296,7 @@ Description:	If enabled, the response from the CAS Server will be parsed for SAM
 		CASValidateURL appropriately; typical URLs are of the form
 		https://login.example.org/cas/samlValidate.
 
-Directive:	CASAllowSubAuth
+Directive:	CASPreserveTicket
 Default:	Off
 Description:	This directive leaves CAS ticket parameters intact when a valid
 		session cookie exists. This helps prevent infinite redirect loops when

--- a/README
+++ b/README
@@ -298,10 +298,9 @@ Description:	If enabled, the response from the CAS Server will be parsed for SAM
 
 Directive:	CASAllowSubAuth
 Default:	Off
-Description:	This directive determines whether subsequent CAS authentication
-		responses are allowed to pass through, leaving the ticket parameter intact.
-		Helps prevent infinite redirect loops when CAS protection is being used
-		at multiple levels.
+Description:	This directive leaves CAS ticket parameters intact when a valid
+		session cookie exists. This helps prevent infinite redirect loops when
+		CAS protection is being used at multiple levels.
 
 Valid Directory/.htaccess Directives
 ------------------------------------

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2116,8 +2116,10 @@ int cas_authenticate(request_rec *r)
 	// prevent infinite redirect loops by allowing subsequent authentication responses to pass through, leaving the ticket parameter intact
 	if(c->CASAllowSubAuth && (ticket != NULL) && (cookieString != NULL) && ap_is_initial_req(r) && isValidCASCookie(r, c, cookieString, &remoteUser, &attrs)) {
 		cas_set_attributes(r, attrs);
-		r->user = remoteUser;
-		set_http_headers(r, c, d, attrs);
+		if(remoteUser) {
+			r->user = remoteUser;
+			set_http_headers(r, c, d, attrs);
+		}
 		if (c->CASDebug)
 			ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "Passing sub-auth response through with ticket parameter intact");
 		return OK;

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2859,7 +2859,7 @@ const command_rec cas_cmds [] = {
 #if MODULE_MAGIC_NUMBER_MAJOR < 20120211
 	AP_INIT_TAKE1("CASAuthoritative", cfg_readCASParameter, (void *) cmd_authoritative, RSRC_CONF, "Set 'On' to reject if access isn't allowed based on our rules; 'Off' (default) to allow checking against other modules too."),
 #endif
-	AP_INIT_TAKE1("CASAllowSubAuth", cfg_readCASParameter, (void *) cmd_allow_sub_auth, RSRC_CONF, "Allow subsequent CAS authentication responses to pass through, leaving the ticket parameter intact. Helps prevent infinite redirect loops when CAS protection is being used at multiple levels."),
+	AP_INIT_TAKE1("CASAllowSubAuth", cfg_readCASParameter, (void *) cmd_allow_sub_auth, RSRC_CONF, "Leave CAS ticket parameters intact when a valid session cookie exists. This helps prevent infinite redirect loops when CAS protection is being used at multiple levels."),
 	AP_INIT_TAKE1(0, 0, 0, 0, 0)
 };
 

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2114,12 +2114,10 @@ int cas_authenticate(request_rec *r)
 	cookieString = getCASCookie(r, (ssl ? d->CASSecureCookie : d->CASCookie));
 
 	// prevent infinite redirect loops by allowing subsequent authentication responses to pass through, leaving the ticket parameter intact
-	if(c->CASAllowSubAuth && (ticket != NULL) && (cookieString != NULL) && ap_is_initial_req(r) && isValidCASCookie(r, c, cookieString, &remoteUser, &attrs)) {
+	if(c->CASAllowSubAuth && (ticket != NULL) && (cookieString != NULL) && ap_is_initial_req(r) && isValidCASCookie(r, c, cookieString, &remoteUser, &attrs) && (remoteUser != NULL)) {
 		cas_set_attributes(r, attrs);
-		if(remoteUser) {
-			r->user = remoteUser;
-			set_http_headers(r, c, d, attrs);
-		}
+		r->user = remoteUser;
+		set_http_headers(r, c, d, attrs);
 		if (c->CASDebug)
 			ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "Passing sub-auth response through with ticket parameter intact");
 		return OK;

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -97,7 +97,7 @@
 #define CAS_DEFAULT_SCRUB_REQUEST_HEADERS NULL
 #define CAS_DEFAULT_SSO_ENABLED FALSE
 #define CAS_DEFAULT_AUTHORITATIVE FALSE
-#define CAS_DEFAULT_ALLOW_SUB_AUTH FALSE
+#define CAS_DEFAULT_PRESERVE_TICKET FALSE
 
 #define CAS_MAX_RESPONSE_SIZE 65536
 #define CAS_MAX_ERROR_SIZE 1024
@@ -124,7 +124,7 @@ typedef struct cas_cfg {
 	unsigned int CASCookieHttpOnly;
 	unsigned int CASSSOEnabled;
 	unsigned int CASAuthoritative;
-	unsigned int CASAllowSubAuth;
+	unsigned int CASPreserveTicket;
 	unsigned int CASValidateSAML;
 	char *CASCertificatePath;
 	char *CASCookiePath;
@@ -169,7 +169,7 @@ typedef enum {
 	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
 	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_httponly,
 	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix,
-	cmd_root_proxied_as, cmd_authoritative, cmd_allow_sub_auth
+	cmd_root_proxied_as, cmd_authoritative, cmd_preserve_ticket
 } valid_cmds;
 
 module AP_MODULE_DECLARE_DATA auth_cas_module;

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -97,6 +97,7 @@
 #define CAS_DEFAULT_SCRUB_REQUEST_HEADERS NULL
 #define CAS_DEFAULT_SSO_ENABLED FALSE
 #define CAS_DEFAULT_AUTHORITATIVE FALSE
+#define CAS_DEFAULT_ALLOW_SUB_AUTH FALSE
 
 #define CAS_MAX_RESPONSE_SIZE 65536
 #define CAS_MAX_ERROR_SIZE 1024
@@ -123,6 +124,7 @@ typedef struct cas_cfg {
 	unsigned int CASCookieHttpOnly;
 	unsigned int CASSSOEnabled;
 	unsigned int CASAuthoritative;
+	unsigned int CASAllowSubAuth;
 	unsigned int CASValidateSAML;
 	char *CASCertificatePath;
 	char *CASCookiePath;
@@ -167,7 +169,7 @@ typedef enum {
 	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
 	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_httponly,
 	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix,
-	cmd_root_proxied_as, cmd_authoritative
+	cmd_root_proxied_as, cmd_authoritative, cmd_allow_sub_auth
 } valid_cmds;
 
 module AP_MODULE_DECLARE_DATA auth_cas_module;


### PR DESCRIPTION
Added capability and config option (CASAllowSubAuth) that allows subsequent CAS authentication responses to pass through, leaving the ticket parameter intact. Helps prevent infinite redirect loops when CAS protection is being used at multiple levels.

See https://github.com/apereo/mod_auth_cas/issues/144 for original inspiration and prototype code.