### PR TITLE
Use apr function to also escape characters that are not in US-ASCII range.

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -46,6 +46,7 @@
 #include "ap_release.h"
 #include "pcre.h"
 #include "apr_buckets.h"
+#include "apr_escape.h"
 #include "apr_file_info.h"
 #include "apr_lib.h"
 #include "apr_md5.h"
@@ -816,17 +817,18 @@ void setCASCookie(request_rec *r, char *cookieName, char *cookieValue, apr_byte_
 
 /*
  * The CAS protocol spec 2.1.1 says the URL value MUST be URL-encoded as described in 2.2 of RFC 1738.
- * The rfc1738 array below represents the 'unsafe' characters from that section.  No encoding is performed
- * on 'control characters' (0x00-0x1F) or characters not used in US-ASCII (0x80-0xFF) - is this a problem?
- * 7/25/2009 - add '+' to list of characters to escape
+ * The apr function 'apr_pescape_urlencoded' encodes the string accordingly.
  */
 
 char *escapeString(const request_rec *r, const char *str)
 {
-	char *rfc1738 = "+ <>\"%{}|\\^~[]`;/?:@=&#";
+	char *rv;
 
-	return(urlEncode(r, str, rfc1738));
+	rv = (char *)apr_pescape_urlencoded(r->pool, str);
 
+	if(rv == NULL) return "";
+
+	return rv;
 }
 
 char *urlEncode(const request_rec *r, const char *str,


### PR DESCRIPTION
We had the issue that if a protected resource contained an umlaut in its name, the authentication procedure failed with error code 400.

This pull request replaces the function to encode the URL string with an apr library function that also encodes characters which are not in the US-ASCII range.

Note that the apr function [`apr_pescape_urlencoded`](https://apr.apache.org/docs/apr/1.5/group___a_p_r___util___escaping.html#ga9caffb30731e3a07a8e23fa6464d35b5) encodes a string according to RFC 1738 like the current implementation.

This pull request contains considerable contributions from <rschmutz@netlabs.ch>.