### PR TITLE
simplify ticket format validation

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -688,48 +688,13 @@ apr_byte_t removeCASParams(request_rec *r)
 
 apr_byte_t validCASTicketFormat(const char *ticket)
 {
-  enum ticket_state {
-    ps,
-    t,
-    dash,
-    postfix,
-    illegal
-  } state = ps;
-
-  if (!*ticket)
-    goto bail;
-
-  while (state != illegal && *ticket) {
-    switch (state) {
-      case ps:
-        if (*ticket != 'P' && *ticket != 'S')
-          goto bail;
-        state = t;
-        break;
-      case t:
-        if (*ticket != 'T')
-          goto bail;
-        state = dash;
-        break;
-      case dash:
-        if (*ticket != '-')
-          goto bail;
-        state = postfix;
-        break;
-      case postfix:
-        if (*ticket != '-' && *ticket != '.' && !isalnum(*ticket))
-          goto bail;
-        break;
-      default:
-        goto bail;
-        break;
-    }
-    ticket++;
-  }
-
+  if (ticket[0] != 'S' && ticket[0] != 'P')
+    return FALSE;
+  if (ticket[1] != 'T')
+    return FALSE;
+  if (ticket[2] != '-')
+    return FALSE;
   return TRUE;
-bail:
-  return FALSE;
 }
 
 char *getCASTicket(request_rec *r)

--- a/tests/mod_auth_cas_test.c
+++ b/tests/mod_auth_cas_test.c
@@ -452,31 +452,31 @@ END_TEST
 
 START_TEST(validCASTicketFormat_test) {
   const char *valid[] = {
+    "ST-",
     "ST-1234",
     "ST-1234-login.example.com"
   };
   const char *invalid[] = {
-    "ST-<^>",
-    "ST-\x22qwe", /* ST-"qwe */
-    "ST-\x25qwe", /* ST-<nak>qwe */
-    "ST-\xc8qwe"  /* ST-<ascii 200>qwe */
+    "",
+    "ST",
+    "T-invalid",
+    "S-invalid",
+    "STinvalid",
   };
   unsigned int i;
 
   for (i = 0; i < ARRAY_SIZE(valid); i++)
-    fail_unless(validCASTicketFormat(valid[i]) == TRUE);
+    fail_unless(validCASTicketFormat(valid[i]) == TRUE, valid[i]);
 
   for (i = 0; i < ARRAY_SIZE(invalid); i++)
-    fail_unless(validCASTicketFormat(invalid[i]) == FALSE);
+    fail_unless(validCASTicketFormat(invalid[i]) == FALSE, invalid[i]);
 }
 END_TEST
 
 START_TEST(getCASTicket_test) {
   char *args = "foo=bar&ticket=ST-1234&baz=zot";
-  char *dupargs = "foo=bar&ticket=ST-^<>&baz=zot&ticket=ST-1234";
-  char *badargs = "foo=bar&ticket=ST-^<>&baz=zot";
+  char *dupargs = "foo=bar&ticket=invalid&baz=zot&ticket=ST-1234";
   char *emptyargs = "";
-  char *truncated_args = "ST-";
   char *rv;
   const char *expected = "ST-1234";
 
@@ -489,15 +489,7 @@ START_TEST(getCASTicket_test) {
   rv = getCASTicket(request);
   fail_unless(strcmp(rv, expected) == 0);
 
-  request->args = apr_pstrdup(request->pool, badargs);
-  rv = getCASTicket(request);
-  fail_unless(rv == NULL);
-
   request->args = apr_pstrdup(request->pool, emptyargs);
-  rv = getCASTicket(request);
-  fail_unless(rv == NULL);
-
-  request->args = apr_pstrdup(request->pool, truncated_args);
   rv = getCASTicket(request);
   fail_unless(rv == NULL);
 


### PR DESCRIPTION
From the [CAS v2 documentation](https://apereo.github.io/cas/6.0.x/protocol/CAS-Protocol-V2-Specification.html#31-service-ticket), there is no need to validate the content of the ticket, the only relevant check is that it needs to begin with "ST-" (and "PT-" for the proxy tickets).