### PR TITLE
Add config directive for SameSite cookie flag.

### DIFF
--- a/README
+++ b/README
@@ -275,6 +275,11 @@ Directive:	CASCookieDomain
 Default:	NULL
 Description:	Specify the value for the 'Domain=' parameter in the Set-Cookie header.
 
+Directive:	CASCookieSameSite
+Default:	NULL
+Description:	Specify the value for the 'SameSite=' parameter in the Set-Cookie header.
+		Allowed values are 'None', 'Lax', and 'Strict'.
+
 Directive:	CASCookieHttpOnly
 Default:	On
 Description:	Set the optional 'HttpOnly' flag for cookies issues by mod_auth_cas.

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -90,6 +90,7 @@
 #define CAS_DEFAULT_ROOT_PROXIED_AS_URL NULL
 #define CAS_DEFAULT_COOKIE_ENTROPY 32
 #define CAS_DEFAULT_COOKIE_DOMAIN NULL
+#define CAS_DEFAULT_COOKIE_SAMESITE NULL
 #define CAS_DEFAULT_COOKIE_HTTPONLY 1
 #define CAS_DEFAULT_COOKIE_TIMEOUT 7200 /* 2 hours */
 #define CAS_DEFAULT_COOKIE_IDLE_TIMEOUT 3600 /* 1 hour */
@@ -134,6 +135,7 @@ typedef struct cas_cfg {
 	char *CASCertificatePath;
 	char *CASCookiePath;
 	char *CASCookieDomain;
+	char *CASCookieSameSite;
 	char *CASGatewayCookieDomain;
 	char *CASAttributeDelimiter;
 	char *CASAttributePrefix;
@@ -175,7 +177,7 @@ typedef struct cas_curl_buffer {
 typedef enum {
 	cmd_version, cmd_debug, cmd_validate_depth, cmd_ca_path, cmd_cookie_path,
 	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
-	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_httponly,
+	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_samesite, cmd_cookie_httponly,
 	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix,
 	cmd_root_proxied_as, cmd_authoritative, cmd_preserve_ticket, cmd_gateway_cookie_domain
 } valid_cmds;
@@ -208,7 +210,7 @@ char *getCASPath(request_rec *r);
 void CASSAMLLogout(request_rec *r, char *body);
 apr_status_t cas_in_filter(ap_filter_t *f, apr_bucket_brigade *bb, ap_input_mode_t mode, apr_read_type_e block, apr_off_t readbytes);
 void deleteCASCacheFile(request_rec *r, char *cookieName);
-void setCASCookie(request_rec *r, char *cookieName, char *cookieValue, apr_byte_t secure, apr_time_t expireTime, char *cookieDomain);
+void setCASCookie(request_rec *r, char *cookieName, char *cookieValue, apr_byte_t secure, apr_time_t expireTime, char *cookieDomain, char *cookieSameSite);
 char *escapeString(const request_rec *r, const char *str);
 char *urlEncode(const request_rec *r, const char *str, const char *charsToEncode);
 char *getCASGateway(request_rec *r);


### PR DESCRIPTION
There are cases, where the SameSite flag must be specified for the CAS cookie to work properly.

This pull request adds the config directive `CASCookieSameSite` to configure the SameSite flag of the CAS cookie. It can be set to the following values: `None`, `Lax`, and `Strict`.

This pull request also solves issue https://github.com/apereo/mod_auth_cas/issues/140.