### PR TITLE
Add config directive for Secure cookie flag.

### DIFF
--- a/README
+++ b/README
@@ -288,7 +288,7 @@ Description:	Set the optional 'HttpOnly' flag for cookies issues by mod_auth_cas
 
 Directive:	CASCookieSecureAttribute
 Default:	Auto
-Description:	Set the optional 'Secure' attribute for cookies issues by mod_auth_cas.
+Description:	Set the optional 'Secure' attribute for cookies issued by mod_auth_cas.
 		Set the Secure attribute as described in in RFC 6265. This flag prevents the
 		mod_auth_cas cookies from being sent over an unencrypted HTTP connection.
 		By default, mod_auth_cas sets the 'Secure' attribute depending on information about

--- a/README
+++ b/README
@@ -286,6 +286,15 @@ Description:	Set the optional 'HttpOnly' flag for cookies issues by mod_auth_cas
 		Set the HttpOnly flag as described in in RFC 6265.  This flag prevents the
 		mod_auth_cas cookies from being accessed by client side Javascript.
 
+Directive:	CASCookieSecureAttribute
+Default:	Auto
+Description:	Set the optional 'Secure' attribute for cookies issues by mod_auth_cas.
+		Set the Secure attribute as described in in RFC 6265. This flag prevents the
+		mod_auth_cas cookies from being sent over an unencrypted HTTP connection.
+		By default, mod_auth_cas sets the 'Secure' attribute depending on information about
+		the connection (the 'Auto' option). The options 'On' and 'Off' can be used to override
+		the automatic behaviour.
+
 Directive:	CASAuthoritative
 Default:	Off
 Description:	This directive determines whether an optional authorization directive

--- a/README
+++ b/README
@@ -286,7 +286,7 @@ Description:	Set the optional 'HttpOnly' flag for cookies issues by mod_auth_cas
 		Set the HttpOnly flag as described in in RFC 6265.  This flag prevents the
 		mod_auth_cas cookies from being accessed by client side Javascript.
 
-Directive:	CASCookieSecureAttribute
+Directive:	CASCookieSecure
 Default:	Auto
 Description:	Set the optional 'Secure' attribute for cookies issued by mod_auth_cas.
 		Set the Secure attribute as described in in RFC 6265. This flag prevents the

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2927,7 +2927,7 @@ const command_rec cas_cmds [] = {
 	AP_INIT_TAKE1("CASCookieSameSite", cfg_readCASParameter, (void *) cmd_cookie_samesite, RSRC_CONF, "Specify SameSite flag header for mod_auth_cas cookie"),
 	AP_INIT_TAKE1("CASGatewayCookieDomain", cfg_readCASParameter, (void *) cmd_gateway_cookie_domain, RSRC_CONF, "Specify domain header for mod_auth_cas gateway cookie"),
 	AP_INIT_TAKE1("CASCookieHttpOnly", cfg_readCASParameter, (void *) cmd_cookie_httponly, RSRC_CONF, "Enable 'HttpOnly' flag for mod_auth_cas cookie (may break RFC compliance)"),
-	AP_INIT_TAKE1("CASCookieSecure", cfg_readCASParameter, (void *) cmd_cookie_secureattribute, RSRC_CONF, "Set the 'Secure' attribute for the mod_auth_cas cookie (Auto, On, Off)"),
+	AP_INIT_TAKE1("CASCookieSecure", cfg_readCASParameter, (void *) cmd_cookie_secure, RSRC_CONF, "Set the 'Secure' attribute for the mod_auth_cas cookie (Auto, On, Off)"),
 	AP_INIT_TAKE1("CASCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for HTTP sessions"),
 	AP_INIT_TAKE1("CASSecureCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASSecureCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for HTTPS sessions"),
 	AP_INIT_TAKE1("CASGatewayCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASGatewayCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for a gateway location"),

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -118,7 +118,7 @@ void *cas_create_server_config(apr_pool_t *pool, server_rec *svr)
 	c->CASCookieSameSite = CAS_DEFAULT_COOKIE_SAMESITE;
 	c->CASGatewayCookieDomain = CAS_DEFAULT_GATEWAY_COOKIE_DOMAIN;
 	c->CASCookieHttpOnly = CAS_DEFAULT_COOKIE_HTTPONLY;
-	c->CASCookieSecureAttribute = CAS_DEFAULT_COOKIE_SECUREATTRIBUTE;
+	c->CASCookieSecure = CAS_DEFAULT_COOKIE_SECURE;
 	c->CASSSOEnabled = CAS_DEFAULT_SSO_ENABLED;
 	c->CASValidateSAML = CAS_DEFAULT_VALIDATE_SAML;
 	c->CASAttributeDelimiter = CAS_DEFAULT_ATTRIBUTE_DELIMITER;
@@ -157,7 +157,7 @@ void *cas_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD)
 	c->CASCookieSameSite = (add->CASCookieSameSite != CAS_DEFAULT_COOKIE_SAMESITE ? add->CASCookieSameSite : base->CASCookieSameSite);
 	c->CASGatewayCookieDomain = (add->CASGatewayCookieDomain != CAS_DEFAULT_GATEWAY_COOKIE_DOMAIN ? add->CASGatewayCookieDomain : base->CASGatewayCookieDomain);
 	c->CASCookieHttpOnly = (add->CASCookieHttpOnly != CAS_DEFAULT_COOKIE_HTTPONLY ? add->CASCookieHttpOnly : base->CASCookieHttpOnly);
-	c->CASCookieSecureAttribute = (add->CASCookieSecureAttribute != CAS_DEFAULT_COOKIE_SECUREATTRIBUTE ? add->CASCookieSecureAttribute : base->CASCookieSecureAttribute);
+	c->CASCookieSecure = (add->CASCookieSecure != CAS_DEFAULT_COOKIE_SECURE ? add->CASCookieSecure : base->CASCookieSecure);
 	c->CASSSOEnabled = (add->CASSSOEnabled != CAS_DEFAULT_SSO_ENABLED ? add->CASSSOEnabled : base->CASSSOEnabled);
 	c->CASValidateSAML = (add->CASValidateSAML != CAS_DEFAULT_VALIDATE_SAML ? add->CASValidateSAML : base->CASValidateSAML);
 #if MODULE_MAGIC_NUMBER_MAJOR < 20120211
@@ -404,15 +404,15 @@ const char *cfg_readCASParameter(cmd_parms *cmd, void *cfg, const char *value)
 			else
 				return(apr_psprintf(cmd->pool, "MOD_AUTH_CAS: Invalid argument to CASCookieHttpOnly - must be 'On' or 'Off'"));
 		break;
-		case cmd_cookie_secureattribute:
+		case cmd_cookie_secure:
 			if(apr_strnatcasecmp(value, "On") == 0)
-				c->CASCookieSecureAttribute = TRUE;
+				c->CASCookieSecure = TRUE;
 			else if(apr_strnatcasecmp(value, "Off") == 0)
-				c->CASCookieSecureAttribute = FALSE;
+				c->CASCookieSecure = FALSE;
 			else if(apr_strnatcasecmp(value, "Auto") == 0)
-				c->CASCookieSecureAttribute = CAS_SECURE_AUTO;
+				c->CASCookieSecure = CAS_SECURE_AUTO;
 			else
-				return(apr_psprintf(cmd->pool, "MOD_AUTH_CAS: Invalid argument to CASCookieSecureAttribute - must be 'Auto', 'On' or 'Off'"));
+				return(apr_psprintf(cmd->pool, "MOD_AUTH_CAS: Invalid argument to CASCookieSecure - must be 'Auto', 'On' or 'Off'"));
 		break;
 		case cmd_sso:
 			if(apr_strnatcasecmp(value, "On") == 0)
@@ -827,8 +827,8 @@ void setCASCookie(request_rec *r, char *cookieName, char *cookieValue, apr_byte_
 	if(NULL != cookieDomain) {
 		domainString = apr_psprintf(r->pool, ";Domain=%s", cookieDomain);
 	}
-	if(CAS_SECURE_AUTO != c->CASCookieSecureAttribute) {
-		secure = c->CASCookieSecureAttribute;
+	if(CAS_SECURE_AUTO != c->CASCookieSecure) {
+		secure = c->CASCookieSecure;
 	}
 	if(NULL != cookieSameSite) {
 		sameSiteString = apr_psprintf(r->pool, ";SameSite=%s", cookieSameSite);
@@ -2927,7 +2927,7 @@ const command_rec cas_cmds [] = {
 	AP_INIT_TAKE1("CASCookieSameSite", cfg_readCASParameter, (void *) cmd_cookie_samesite, RSRC_CONF, "Specify SameSite flag header for mod_auth_cas cookie"),
 	AP_INIT_TAKE1("CASGatewayCookieDomain", cfg_readCASParameter, (void *) cmd_gateway_cookie_domain, RSRC_CONF, "Specify domain header for mod_auth_cas gateway cookie"),
 	AP_INIT_TAKE1("CASCookieHttpOnly", cfg_readCASParameter, (void *) cmd_cookie_httponly, RSRC_CONF, "Enable 'HttpOnly' flag for mod_auth_cas cookie (may break RFC compliance)"),
-	AP_INIT_TAKE1("CASCookieSecureAttribute", cfg_readCASParameter, (void *) cmd_cookie_secureattribute, RSRC_CONF, "Enable 'Secure' attribute for mod_auth_cas cookie (may break RFC compliance)"),
+	AP_INIT_TAKE1("CASCookieSecure", cfg_readCASParameter, (void *) cmd_cookie_secureattribute, RSRC_CONF, "Set the 'Secure' attribute for the mod_auth_cas cookie (Auto, On, Off)"),
 	AP_INIT_TAKE1("CASCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for HTTP sessions"),
 	AP_INIT_TAKE1("CASSecureCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASSecureCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for HTTPS sessions"),
 	AP_INIT_TAKE1("CASGatewayCookie", ap_set_string_slot, (void *) APR_OFFSETOF(cas_dir_cfg, CASGatewayCookie), ACCESS_CONF|OR_AUTHCFG, "Define the cookie name for a gateway location"),

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -67,6 +67,7 @@
 	#endif
 #endif
 
+#define CAS_SECURE_AUTO 2
 #define CAS_DEFAULT_VERSION 2
 #define CAS_DEFAULT_DEBUG FALSE
 #define CAS_DEFAULT_SCOPE NULL
@@ -92,6 +93,7 @@
 #define CAS_DEFAULT_COOKIE_DOMAIN NULL
 #define CAS_DEFAULT_COOKIE_SAMESITE NULL
 #define CAS_DEFAULT_COOKIE_HTTPONLY 1
+#define CAS_DEFAULT_COOKIE_SECUREATTRIBUTE 2
 #define CAS_DEFAULT_COOKIE_TIMEOUT 7200 /* 2 hours */
 #define CAS_DEFAULT_COOKIE_IDLE_TIMEOUT 3600 /* 1 hour */
 #define CAS_DEFAULT_CACHE_CLEAN_INTERVAL  1800 /* 30 minutes */
@@ -128,6 +130,7 @@ typedef struct cas_cfg {
 	unsigned int CASTimeout;
 	unsigned int CASIdleTimeout;
 	unsigned int CASCookieHttpOnly;
+	unsigned int CASCookieSecureAttribute;
 	unsigned int CASSSOEnabled;
 	unsigned int CASAuthoritative;
 	unsigned int CASPreserveTicket;
@@ -178,7 +181,7 @@ typedef enum {
 	cmd_version, cmd_debug, cmd_validate_depth, cmd_ca_path, cmd_cookie_path,
 	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
 	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_samesite, cmd_cookie_httponly,
-	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix,
+	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix, cmd_cookie_secureattribute,
 	cmd_root_proxied_as, cmd_authoritative, cmd_preserve_ticket, cmd_gateway_cookie_domain
 } valid_cmds;
 

--- a/src/mod_auth_cas.h
+++ b/src/mod_auth_cas.h
@@ -93,7 +93,7 @@
 #define CAS_DEFAULT_COOKIE_DOMAIN NULL
 #define CAS_DEFAULT_COOKIE_SAMESITE NULL
 #define CAS_DEFAULT_COOKIE_HTTPONLY 1
-#define CAS_DEFAULT_COOKIE_SECUREATTRIBUTE 2
+#define CAS_DEFAULT_COOKIE_SECURE CAS_SECURE_AUTO
 #define CAS_DEFAULT_COOKIE_TIMEOUT 7200 /* 2 hours */
 #define CAS_DEFAULT_COOKIE_IDLE_TIMEOUT 3600 /* 1 hour */
 #define CAS_DEFAULT_CACHE_CLEAN_INTERVAL  1800 /* 30 minutes */
@@ -130,7 +130,7 @@ typedef struct cas_cfg {
 	unsigned int CASTimeout;
 	unsigned int CASIdleTimeout;
 	unsigned int CASCookieHttpOnly;
-	unsigned int CASCookieSecureAttribute;
+	unsigned int CASCookieSecure;
 	unsigned int CASSSOEnabled;
 	unsigned int CASAuthoritative;
 	unsigned int CASPreserveTicket;
@@ -181,7 +181,7 @@ typedef enum {
 	cmd_version, cmd_debug, cmd_validate_depth, cmd_ca_path, cmd_cookie_path,
 	cmd_loginurl, cmd_validateurl, cmd_proxyurl, cmd_cookie_entropy, cmd_session_timeout,
 	cmd_idle_timeout, cmd_cache_interval, cmd_cookie_domain, cmd_cookie_samesite, cmd_cookie_httponly,
-	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix, cmd_cookie_secureattribute,
+	cmd_sso, cmd_validate_saml, cmd_attribute_delimiter, cmd_attribute_prefix, cmd_cookie_secure,
 	cmd_root_proxied_as, cmd_authoritative, cmd_preserve_ticket, cmd_gateway_cookie_domain
 } valid_cmds;
 


### PR DESCRIPTION
There are cases, where the Secure flag must be specified for the CAS cookie to work properly. At the moment, the Secure flag is set automatically for secure cookies, but there are cases where this approach fails. 

This pull request adds the config directive CASCookieSecureAttribute to manually override the automatic behaviour and force the Secure flag to be set or unset. The directive accepts the values `On`, `Off`, and `Auto` (default).

This pull request relates to https://github.com/apereo/mod_auth_cas/pull/190 because some browsers only accept `SameSite=None` if `Secure` is also set (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#Fixing_common_warnings).