### PR TITLE
Replace bespoke cookie parsing with ap_cookie_read()

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,7 @@ The following development libraries and utilities must be installed:
 * OpenSSL - 0.9.8c or higher
 * Apache Portable Runtime - 1.5.0 or higher
 * Apache Portable Runtime Utilities - 1.3.0 or higher
-* Apache Web Server - 2.2.3 or higher
+* Apache Web Server - 2.4 or higher
 * libcurl - 7.18.2 or higher
 * libpcre - 7.8 or higher
 

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -899,7 +899,7 @@ char *urlEncode(const request_rec *r, const char *str,
 		escaped = FALSE;
 		for(i = 0; i < limit; i++) {
 			if(*q == charsToEncode[i]) {
-				sprintf(p, "%%%x", charsToEncode[i]);
+				sprintf(p, "%%%02x", charsToEncode[i]);
 				p+= 3;
 				escaped = TRUE;
 				break;

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -781,9 +781,9 @@ char *getCASTicket(request_rec *r)
 
 char *getCASCookie(request_rec *r, char *cookieName)
 {
-	char *rv = NULL;
+	const char *rv = NULL;
 	ap_cookie_read(r, cookieName, &rv, 0);
-	return rv;
+	return(apr_pstrdup(r->pool, rv));
 }
 
 void setCASCookie(request_rec *r, char *cookieName, char *cookieValue, apr_byte_t secure, apr_time_t expireTime, char *cookieDomain, char *cookieSameSite)

--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -53,6 +53,7 @@
 #include "apr_thread_mutex.h"
 #include "apr_strings.h"
 #include "apr_xml.h"
+#include "util_cookies.h"
 
 #include "cas_saml_attr.h"
 
@@ -780,26 +781,8 @@ char *getCASTicket(request_rec *r)
 
 char *getCASCookie(request_rec *r, char *cookieName)
 {
-	char *cookie, *tokenizerCtx, *rv = NULL;
-	char *cookies = apr_pstrdup(r->pool, (char *) apr_table_get(r->headers_in, "Cookie"));
-
-	if(cookies != NULL) {
-		/* tokenize on ; to find the cookie we want */
-		cookie = apr_strtok(cookies, ";", &tokenizerCtx);
-		while (cookie != NULL) {
-			while (*cookie == ' ') {
-				cookie++;
-			}
-			if (strncmp(cookie, cookieName, strlen(cookieName)) == 0) {
-			  /* skip to the meat of the parameter (the value after the '=') */
-				cookie += (strlen(cookieName)+1);
-				rv = apr_pstrdup(r->pool, cookie);
-				break;
-			}
-			cookie = apr_strtok(NULL, ";", &tokenizerCtx);
-		}
-	}
-
+	char *rv = NULL;
+	ap_cookie_read(r, cookieName, &rv, 0);
 	return rv;
 }
 


### PR DESCRIPTION
Simplify the code by moving the cookie parsing to use ap_cookie_read(). We're running that patch on several servers in Wikimedia's CAS installation without problems.