### PR TITLE
Patch obsolete autotools m4 macro (AC_PROG_LIBTOOL).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AX_CHECK_COMPILE_FLAG([-Wno-unused-parameter],[CFLAGS="${CFLAGS} -Wno-unused-par
 AX_CHECK_COMPILE_FLAG([-Wpointer-arith],[CFLAGS="${CFLAGS} -Wpointer-arith"])
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes],[CFLAGS="${CFLAGS} -Wstrict-prototypes"])
 
-AC_PROG_LIBTOOL
+LT_INIT
 AC_SUBST(INCLTDL)
 AC_SUBST(LIBLTDL)
 


### PR DESCRIPTION
Something that was caught during the r[eview process](https://bugzilla.redhat.com/show_bug.cgi?id=2173751) to get mod_auth_cas back in Fedora/EPEL is that a deprecated libtool m4 macro is still being used (AC_PROG_LIBTOOL).  Luckily, it seems this was the only one line that needed updating and simply replacing that line with `LT_INIT` allowed it to compile normally.  