### PR TITLE
readme: fix capitalization in AuthType directive

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ Protect a "Location" or "Directory" block in your Apache
 configuration:
 
 	<Location /secured>
-		Authtype CAS
+		AuthType CAS
 		Require valid-user
 	</Location>
 
@@ -89,7 +89,7 @@ case-sensitive):
 	CASValidateSAML On
 
 	<Location /secured>
-		Authtype CAS
+		AuthType CAS
 		Require cas-attribute edupersonaffiliation:staff
 	</Location>
 


### PR DESCRIPTION
This directive is suppose to be camel-cased: https://httpd.apache.org/docs/2.4/mod/mod_authn_core.html#authtype